### PR TITLE
[Update]Rebuild Docker Images

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -26,7 +26,7 @@ jobs:
           ls 
 
       - name: Upload UI artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: UI
           path: ui/dist/  # 上传 dist 目录
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: UI
           path: src/main/resources/static/
@@ -57,7 +57,7 @@ jobs:
         env:
           version: ${{ inputs.version }}
       - name: Upload jar artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar
           path: target/  # 上传 target 目录
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .
@@ -109,7 +109,7 @@ jobs:
           arch: aarch64
 
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .
@@ -149,7 +149,7 @@ jobs:
           arch: armv7
 
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .
@@ -233,7 +233,7 @@ jobs:
         run: |
           mkdir tmp
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: tmp/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,7 +27,7 @@ jobs:
           ls 
 
       - name: Upload UI artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: UI
           path: ui/dist/  # 上传 dist 目录
@@ -58,7 +58,7 @@ jobs:
         env:
           version: ${{ inputs.version }}
       - name: Upload jar artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar
           path: target/  # 上传 target 目录

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: UI
           path: src/main/resources/static/
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .
@@ -121,7 +121,7 @@ jobs:
           arch: aarch64
 
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .
@@ -175,7 +175,7 @@ jobs:
           arch: armv7
 
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: .
@@ -269,7 +269,7 @@ jobs:
         run: |
           mkdir tmp
       - name: Download jar artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV WORKDIR=/tmp/setup_tools
 
 RUN set -eux; \
     apt update && \
-    apt install -y libicu \
+    apt install -y libicu-dev && \
     apt install -y --no-install-recommends gnupg ca-certificates curl wget tar && \
     curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,55 @@
-FROM yajuhua/podcast2-base-v2:latest
+FROM debian:bookworm-slim
 COPY app.jar /
 COPY starter.sh /
+
 EXPOSE 8088
 EXPOSE 5005
+
 ENV LANG=zh_CN.utf8
 ENV RUNNING_IN_DOCKER=true
-RUN yt-dlp -U
+ENV BIN_DIR=/usr/local/bin
+ENV WORKDIR=/tmp/setup_tools
+
+RUN set -eux; \
+    apt update && \
+    apt install -y libicu \
+    apt install -y --no-install-recommends gnupg ca-certificates curl wget tar && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
+    apt update && apt install -y --no-install-recommends zulu8-ca-jre-headless && \
+    mkdir -p ${WORKDIR} && cd ${WORKDIR} && \
+    ARCH=$(uname -m) && \
+    echo "系统架构: $ARCH" && \
+    if [ "$ARCH" = "armv7l" ]; then \
+        wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l -O yt-dlp && \
+        chmod +x yt-dlp && mv yt-dlp ${BIN_DIR}/yt-dlp && \
+        wget -q https://github.com/P3TERX/Aria2-Pro-Core/releases/download/1.36.0_2021.08.22/aria2-1.36.0-static-linux-armhf.tar.gz && \
+        tar -xzf aria2-1.36.0-static-linux-armhf.tar.gz -C ${BIN_DIR} && \
+        wget -q https://github.com/yajuhua/podcast2/raw/refs/heads/v2/ffmpeg-package/linux/armv7/ffmpeg -O ${BIN_DIR}/ffmpeg && \
+        chmod +x ${BIN_DIR}/ffmpeg; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64 -O yt-dlp && \
+        chmod +x yt-dlp && mv yt-dlp ${BIN_DIR}/yt-dlp && \
+        wget -q https://github.com/nilaoda/N_m3u8DL-RE/releases/download/v0.3.0-beta/N_m3u8DL-RE_v0.3.0-beta_linux-arm64_20241203.tar.gz && \
+        tar -xzf N_m3u8DL-RE_v0.3.0-beta_linux-arm64_20241203.tar.gz -C ${BIN_DIR} && \
+        wget -q https://github.com/P3TERX/Aria2-Pro-Core/releases/download/1.36.0_2021.08.22/aria2-1.36.0-static-linux-arm64.tar.gz && \
+        tar -xzf aria2-1.36.0-static-linux-arm64.tar.gz -C ${BIN_DIR} && \
+        wget -q https://github.com/yajuhua/podcast2/raw/refs/heads/v2/ffmpeg-package/linux/arm64/ffmpeg -O ${BIN_DIR}/ffmpeg && \
+        chmod +x ${BIN_DIR}/ffmpeg; \
+    elif [ "$ARCH" = "x86_64" ]; then \
+        wget -q https://github.com/nilaoda/N_m3u8DL-RE/releases/download/v0.3.0-beta/N_m3u8DL-RE_v0.3.0-beta_linux-x64_20241203.tar.gz && \
+        tar -xzf N_m3u8DL-RE_v0.3.0-beta_linux-x64_20241203.tar.gz -C ${BIN_DIR} && \
+        wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -O yt-dlp && \
+        chmod +x yt-dlp && mv yt-dlp ${BIN_DIR}/yt-dlp && \
+        wget -q https://github.com/P3TERX/Aria2-Pro-Core/releases/download/1.36.0_2021.08.22/aria2-1.36.0-static-linux-amd64.tar.gz && \
+        tar -xzf aria2-1.36.0-static-linux-amd64.tar.gz -C ${BIN_DIR} && \
+        wget -q https://github.com/yajuhua/podcast2/raw/refs/heads/v2/ffmpeg-package/linux/amd64/ffmpeg -O ${BIN_DIR}/ffmpeg && \
+        chmod +x ${BIN_DIR}/ffmpeg; \
+    else \
+        echo "不支持的架构: $ARCH" >&2 && exit 1; \
+    fi && \
+    rm -rf ${WORKDIR} && \
+    apt clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /
 CMD ["sh","starter.sh"]
-
-LABEL author.email="yajuhua@outlook.com"  author.name="yajuhua"
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:bookworm-slim
+
 COPY app.jar /
 COPY starter.sh /
 
@@ -12,19 +13,28 @@ ENV WORKDIR=/tmp/setup_tools
 
 RUN set -eux; \
     apt update && \
-    apt install -y libicu-dev && \
-    apt install -y --no-install-recommends gnupg ca-certificates curl wget tar && \
+    apt install -y --no-install-recommends libicu-dev gnupg ca-certificates curl wget tar && \
     curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
-    apt update && apt install -y --no-install-recommends zulu8-ca-jre-headless && \
+    apt update && \
     mkdir -p ${WORKDIR} && cd ${WORKDIR} && \
     ARCH=$(uname -m) && \
     echo "系统架构: $ARCH" && \
+    if [ "$ARCH" = "armv7l" ]; then \
+        echo "使用 tar.gz 安装 JRE for armv7l"; \
+        wget -q https://cdn.azul.com/zulu-embedded/bin/zulu8.76.0.17-ca-jre8.0.402-linux_aarch32hf.tar.gz; \
+        tar -xzf zulu8.76.0.17-ca-jre8.0.402-linux_aarch32hf.tar.gz -C /usr/local; \
+        ln -sf /usr/local/zulu8.76.0.17-ca-jre8.0.402-linux_aarch32hf/bin/java /usr/local/bin/java; \
+        rm -f zulu8.76.0.17-ca-jre8.0.402-linux_aarch32hf.tar.gz; \
+    else \
+        apt install -y --no-install-recommends zulu8-ca-jre-headless; \
+    fi && \
     if [ "$ARCH" = "armv7l" ]; then \
         wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l -O yt-dlp && \
         chmod +x yt-dlp && mv yt-dlp ${BIN_DIR}/yt-dlp && \
         wget -q https://github.com/P3TERX/Aria2-Pro-Core/releases/download/1.36.0_2021.08.22/aria2-1.36.0-static-linux-armhf.tar.gz && \
         tar -xzf aria2-1.36.0-static-linux-armhf.tar.gz -C ${BIN_DIR} && \
+        rm -f aria2-1.36.0-static-linux-armhf.tar.gz && \
         wget -q https://github.com/yajuhua/podcast2/raw/refs/heads/v2/ffmpeg-package/linux/armv7/ffmpeg -O ${BIN_DIR}/ffmpeg && \
         chmod +x ${BIN_DIR}/ffmpeg; \
     elif [ "$ARCH" = "aarch64" ]; then \
@@ -32,17 +42,21 @@ RUN set -eux; \
         chmod +x yt-dlp && mv yt-dlp ${BIN_DIR}/yt-dlp && \
         wget -q https://github.com/nilaoda/N_m3u8DL-RE/releases/download/v0.3.0-beta/N_m3u8DL-RE_v0.3.0-beta_linux-arm64_20241203.tar.gz && \
         tar -xzf N_m3u8DL-RE_v0.3.0-beta_linux-arm64_20241203.tar.gz -C ${BIN_DIR} && \
+        rm -f N_m3u8DL-RE_v0.3.0-beta_linux-arm64_20241203.tar.gz && \
         wget -q https://github.com/P3TERX/Aria2-Pro-Core/releases/download/1.36.0_2021.08.22/aria2-1.36.0-static-linux-arm64.tar.gz && \
         tar -xzf aria2-1.36.0-static-linux-arm64.tar.gz -C ${BIN_DIR} && \
+        rm -f aria2-1.36.0-static-linux-arm64.tar.gz && \
         wget -q https://github.com/yajuhua/podcast2/raw/refs/heads/v2/ffmpeg-package/linux/arm64/ffmpeg -O ${BIN_DIR}/ffmpeg && \
         chmod +x ${BIN_DIR}/ffmpeg; \
     elif [ "$ARCH" = "x86_64" ]; then \
         wget -q https://github.com/nilaoda/N_m3u8DL-RE/releases/download/v0.3.0-beta/N_m3u8DL-RE_v0.3.0-beta_linux-x64_20241203.tar.gz && \
         tar -xzf N_m3u8DL-RE_v0.3.0-beta_linux-x64_20241203.tar.gz -C ${BIN_DIR} && \
+        rm -f N_m3u8DL-RE_v0.3.0-beta_linux-x64_20241203.tar.gz && \
         wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -O yt-dlp && \
         chmod +x yt-dlp && mv yt-dlp ${BIN_DIR}/yt-dlp && \
         wget -q https://github.com/P3TERX/Aria2-Pro-Core/releases/download/1.36.0_2021.08.22/aria2-1.36.0-static-linux-amd64.tar.gz && \
         tar -xzf aria2-1.36.0-static-linux-amd64.tar.gz -C ${BIN_DIR} && \
+        rm -f aria2-1.36.0-static-linux-amd64.tar.gz && \
         wget -q https://github.com/yajuhua/podcast2/raw/refs/heads/v2/ffmpeg-package/linux/amd64/ffmpeg -O ${BIN_DIR}/ffmpeg && \
         chmod +x ${BIN_DIR}/ffmpeg; \
     else \
@@ -52,4 +66,4 @@ RUN set -eux; \
     apt clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
-CMD ["sh","starter.sh"]
+CMD ["sh", "starter.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,18 @@ COPY starter.sh /
 EXPOSE 8088
 EXPOSE 5005
 
-ENV LANG=zh_CN.utf8
+ENV LANG=zh_CN.UTF-8
+ENV LANGUAGE=zh_CN:zh
+ENV LC_ALL=zh_CN.UTF-8
 ENV RUNNING_IN_DOCKER=true
 ENV BIN_DIR=/usr/local/bin
 ENV WORKDIR=/tmp/setup_tools
 
 RUN set -eux; \
     apt update && \
-    apt install -y --no-install-recommends libicu-dev gnupg ca-certificates curl wget tar && \
+    apt install -y --no-install-recommends gnupg ca-certificates curl wget tar fonts-wqy-microhei locales && \
+    sed -i '/zh_CN.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen zh_CN.UTF-8 && \
     curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt update && \
@@ -27,7 +31,7 @@ RUN set -eux; \
         ln -sf /usr/local/zulu8.76.0.17-ca-jre8.0.402-linux_aarch32hf/bin/java /usr/local/bin/java; \
         rm -f zulu8.76.0.17-ca-jre8.0.402-linux_aarch32hf.tar.gz; \
     else \
-        apt install -y --no-install-recommends zulu8-ca-jre-headless; \
+        apt install -y --no-install-recommends zulu8-ca-jre-headless libicu-dev; \
     fi && \
     if [ "$ARCH" = "armv7l" ]; then \
         wget -q https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_armv7l -O yt-dlp && \


### PR DESCRIPTION
`yajuhua/podcast2-base-v2`基础镜像是基于centos7的，目前已经停止维护了。`podcast2 v2.5.3`以后的版本将基于`debian:bookworm-slim`。